### PR TITLE
fix(dataframes): Fix map_series not being able to map values to nan

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.6
+current_version = 0.4.7
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # owid-datautils
-![version](https://img.shields.io/badge/version-0.4.6-blue)
+![version](https://img.shields.io/badge/version-0.4.7-blue)
 ![version](https://img.shields.io/badge/python-3.8|3.9|3.10-blue.svg?&logo=python&logoColor=yellow) [![codecov](https://codecov.io/gh/owid/owid-datautils-py/branch/main/graph/badge.svg?token=2emTQEJedw)](https://codecov.io/gh/owid/owid-datautils-py)
 [![Documentation Status](https://readthedocs.org/projects/owid-datautils/badge/?version=latest)](https://docs.owid.io/projects/owid-datautils/en/latest/?badge=latest)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2022, Our World In Data"
 author = "Our World In Data"
 
 # The full version, including alpha/beta/rc tags
-release = "0.4.6"
+release = "0.4.7"
 
 
 # -- General configuration ---------------------------------------------------

--- a/owid/datautils/__init__.py
+++ b/owid/datautils/__init__.py
@@ -1,3 +1,3 @@
 """Library to support the work of the Data Team at Our World in Data."""
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-datautils"
-version = "0.4.6"
+version = "0.4.7"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = ["Our World In Data <tech@ourworldindata.org>"]
 license = "MIT"

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -888,6 +888,16 @@ class TestMapSeries:
             series_out
         )
 
+    def test_mapping_to_nan(self):
+        # Even if make_unmapped_values_nan is False, we want to keep nan values if we are intentionally mapping a value
+        # to nan. For example, if the mapping is {"bad_value": np.nan} we want to keep that nan.
+        mapping = {2: 20, 3: np.nan}
+        series_in = pd.Series([1, 2, 3])
+        series_out = pd.Series([1, 20, np.nan])
+        assert dataframes.map_series(
+            series=series_in, mapping=mapping, make_unmapped_values_nan=False
+        ).equals(series_out)
+
 
 class TestConcatenate:
     def test_concat_categoricals(self):


### PR DESCRIPTION
Currently, `dataframes.map_series()` is not able to map values to nan. The reason is as follows:
First, it applies the mapping using `map`, which replaces all values that were not in the mapping by nan.
So, if `make_unmapped_values_nan` is False, we need to bring those nans back to their original values, which is what we currently do.
However, we are not considering that one may actually want to map certain values to nan.
In other words, if I create a mapping {"bad_value": np.nan}, I want `dataframes.map_series` to map "bad_values" to nan.
This PR fixes that issue.

Note: The reason why we created this function is because pandas' `replace` was too slow on big dataframes. We should check that this fix is not making `map_series` too slow.
