### PR TITLE
Combine overlapping dataframes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.8
+current_version = 0.4.9
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # owid-datautils
-![version](https://img.shields.io/badge/version-0.4.8-blue)
+![version](https://img.shields.io/badge/version-0.4.9-blue)
 ![version](https://img.shields.io/badge/python-3.8|3.9|3.10-blue.svg?&logo=python&logoColor=yellow) [![codecov](https://codecov.io/gh/owid/owid-datautils-py/branch/main/graph/badge.svg?token=2emTQEJedw)](https://codecov.io/gh/owid/owid-datautils-py)
 [![Documentation Status](https://readthedocs.org/projects/owid-datautils/badge/?version=latest)](https://docs.owid.io/projects/owid-datautils/en/latest/?badge=latest)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2022, Our World In Data"
 author = "Our World In Data"
 
 # The full version, including alpha/beta/rc tags
-release = "0.4.8"
+release = "0.4.9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/owid/datautils/__init__.py
+++ b/owid/datautils/__init__.py
@@ -1,3 +1,3 @@
 """Library to support the work of the Data Team at Our World in Data."""
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-datautils"
-version = "0.4.8"
+version = "0.4.9"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = ["Our World In Data <tech@ourworldindata.org>"]
 license = "MIT"


### PR DESCRIPTION
Add function that combines two overlapping dataframes. This is not exactly a merge, and it's more useful than a simple concat.
~@Marigold I think this function might be slow for big dataframes, but for the moment I find it quite useful. Also, I wasn't sure what to do with indexed dataframes, so I imposed that dataframes must have a dummy index, and `index_columns` must be declared. I'm sure this could be relaxed, and `index_columns` could be None by default, and `index_columns` would then be the actual indexes of the dataframes. But I didn't want to overcomplicate things (especially because I tend to avoid working with multiindex dataframes).~
This has been solved with the changes suggested by @Marigold.