### PR TITLE
enhance(map_series): optimize for categoricals

### DIFF
--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -1,7 +1,7 @@
 """Objects related to pandas dataframes."""
 
 import warnings
-from typing import Tuple, Union, List, Any, Dict, Optional, cast, Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -405,6 +405,19 @@ def map_series(
         Mapped series.
 
     """
+    # If given category, only map category names and return category type.
+    if series.dtype == "category":
+        new_categories = map_series(
+            pd.Series(series.cat.categories),
+            mapping=mapping,
+            make_unmapped_values_nan=make_unmapped_values_nan,
+            warn_on_missing_mappings=warn_on_missing_mappings,
+            warn_on_unused_mappings=warn_on_unused_mappings,
+            show_full_warning=show_full_warning,
+        )
+        category_mapping = dict(zip(series.cat.categories, new_categories))
+        return cast(pd.Series, series.cat.rename_categories(category_mapping))
+
     # Translate values in series following the mapping.
     series_mapped = series.map(mapping)
     if not make_unmapped_values_nan:

--- a/owid/datautils/geo.py
+++ b/owid/datautils/geo.py
@@ -415,7 +415,7 @@ def harmonize_countries(
 
     # Replace country names following the mapping given in the countries file.
     # Countries in dataframe that are not in mapping will be either left unchanged of converted to nan.
-    df_harmonized = df.copy()
+    df_harmonized = df.copy(deep=False)
     df_harmonized[country_col] = map_series(
         series=df[country_col],
         mapping=countries,

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -2,10 +2,11 @@
 
 """
 
+from typing import Any, Dict
+
 import numpy as np
 import pandas as pd
 from pytest import warns
-from typing import Any, Dict
 
 from owid.datautils import dataframes
 
@@ -897,6 +898,19 @@ class TestMapSeries:
         assert dataframes.map_series(
             series=series_in, mapping=mapping, make_unmapped_values_nan=False
         ).equals(series_out)
+
+    def test_map_categorical(self):
+        series_in = pd.Series(
+            ["country_01", "country_02", "country_03", np.nan]
+        ).astype("category")
+        series_out = pd.Series(["Country 1", "Country 2", "country_03", np.nan]).astype(
+            "category"
+        )
+        out = dataframes.map_series(
+            series=series_in, mapping=self.mapping, make_unmapped_values_nan=False
+        )
+        assert out.equals(series_out)
+        assert out.dtype == "category"
 
 
 class TestConcatenate:

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -4,15 +4,13 @@
 
 import json
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 import numpy as np
 import pandas as pd
 from pytest import warns
 
-from owid.datautils import dataframes
-from owid.datautils import geo
-
+from owid.datautils import dataframes, geo
 
 mock_countries = {
     "country_02": "Country 2",
@@ -180,6 +178,9 @@ class TestHarmonizeCountries:
             warn_on_unused_countries=False,
             warn_on_missing_countries=False,
         ).equals(df_out)
+
+        # input dataframe is unchanged
+        assert df_in.country.tolist() == ["Country 1", "country_02"]
 
     def test_one_country_unchanged_and_another_unknown(self, _):
         df_in = pd.DataFrame(


### PR DESCRIPTION
When processing GBD dataset we've found that `map_series` could be improved when inputs are categories and reduce CPU & memory usage.