### PR TITLE
fix(dataframes): Fix map series for categoricals

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.13
+current_version = 0.4.14
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # owid-datautils
-![version](https://img.shields.io/badge/version-0.4.13-blue)
+![version](https://img.shields.io/badge/version-0.4.14-blue)
 ![version](https://img.shields.io/badge/python-3.8|3.9|3.10-blue.svg?&logo=python&logoColor=yellow) [![codecov](https://codecov.io/gh/owid/owid-datautils-py/branch/main/graph/badge.svg?token=2emTQEJedw)](https://codecov.io/gh/owid/owid-datautils-py)
 [![Documentation Status](https://readthedocs.org/projects/owid-datautils/badge/?version=latest)](https://docs.owid.io/projects/owid-datautils/en/latest/?badge=latest)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2022, Our World In Data"
 author = "Our World In Data"
 
 # The full version, including alpha/beta/rc tags
-release = "0.4.13"
+release = "0.4.14"
 
 
 # -- General configuration ---------------------------------------------------

--- a/owid/datautils/__init__.py
+++ b/owid/datautils/__init__.py
@@ -1,3 +1,3 @@
 """Library to support the work of the Data Team at Our World in Data."""
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"

--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -470,10 +470,17 @@ def rename_categories(series: pd.Series, mapping: Dict[Any, Any]) -> pd.Series:
     It should be as fast as pd.Series.cat.rename_categories if there are no non-unique categories.
     """
     assert series.dtype == "category"
+
+    series = series.copy()
+
     new_mapping = {}
     for map_from, map_to in mapping.items():
+        # Map nulls right away
+        if pd.isnull(map_to):
+            series[series == map_from] = np.nan
+
         # Non-unique category, replace it first
-        if map_to in new_mapping.values():
+        elif map_to in new_mapping.values():
             # Find the category that maps to map_to
             series[series == map_from] = [
                 k for k, v in new_mapping.items() if v == map_to

--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -474,7 +474,7 @@ def rename_categories(series: pd.Series, mapping: Dict[Any, Any]) -> pd.Series:
 
     series = series.copy()
 
-    new_mapping = {}
+    new_mapping: Dict[Any, Any] = {}
     for map_from, map_to in mapping.items():
         # Map nulls right away
         if pd.isnull(map_to):
@@ -489,7 +489,10 @@ def rename_categories(series: pd.Series, mapping: Dict[Any, Any]) -> pd.Series:
         else:
             new_mapping[map_from] = map_to
 
-    return series.cat.rename_categories(new_mapping).cat.remove_unused_categories()
+    return cast(
+        pd.Series,
+        series.cat.rename_categories(new_mapping).cat.remove_unused_categories(),
+    )
 
 
 def concatenate(dfs: List[pd.DataFrame], **kwargs: Any) -> pd.DataFrame:

--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -466,8 +466,8 @@ def rename_categories(series: pd.Series, mapping: Dict[Any, Any]) -> pd.Series:
     """Alternative to pd.Series.cat.rename_categories which supports non-unique categories.
 
     We do that by replacing non-unique categories first and then mapping with unique categories.
-
-    It should be as fast as pd.Series.cat.rename_categories if there are no non-unique categories.
+    Unused categories are removed during the process. It should be as fast as
+    pd.Series.cat.rename_categories if there are no non-unique categories.
     """
     if series.dtype != "category":
         raise ValueError("Series must be of type category.")
@@ -489,9 +489,12 @@ def rename_categories(series: pd.Series, mapping: Dict[Any, Any]) -> pd.Series:
         else:
             new_mapping[map_from] = map_to
 
+    # NOTE: removing unused categories is necessary because of renaming
     return cast(
         pd.Series,
-        series.cat.rename_categories(new_mapping).cat.remove_unused_categories(),
+        series.cat.remove_unused_categories()
+        .cat.rename_categories(new_mapping)
+        .cat.remove_unused_categories(),
     )
 
 

--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -463,13 +463,14 @@ def map_series(
 
 
 def rename_categories(series: pd.Series, mapping: Dict[Any, Any]) -> pd.Series:
-    """Alternative to pd.Series.cat.rename_categories which supports non-unique categories
-    in category map (two categories can map to a single category). We do that by replacing
-    non-unique categories first and then mapping with unique categories.
+    """Alternative to pd.Series.cat.rename_categories which supports non-unique categories.
+
+    We do that by replacing non-unique categories first and then mapping with unique categories.
 
     It should be as fast as pd.Series.cat.rename_categories if there are no non-unique categories.
     """
-    assert series.dtype == "category"
+    if series.dtype != "category":
+        raise ValueError("Series must be of type category.")
 
     series = series.copy()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-datautils"
-version = "0.4.13"
+version = "0.4.14"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = ["Our World In Data <tech@ourworldindata.org>"]
 license = "MIT"

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -929,6 +929,31 @@ class TestMapSeries:
         assert out.equals(series_out)
         assert out.dtype == "category"
 
+    def test_map_categorical_with_nan(self):
+        series_in = pd.Series(
+            ["country_01", "country_02", "country_03", np.nan]
+        ).astype("category")
+        mapping = {
+            "country_01": "Country 1",
+            "country_02": np.nan,
+        }
+
+        out = dataframes.map_series(
+            series=series_in, mapping=mapping, make_unmapped_values_nan=False
+        )
+        assert out.equals(
+            pd.Series(["Country 1", np.nan, "country_03", np.nan]).astype("category")
+        )
+        assert out.dtype == "category"
+
+        out = dataframes.map_series(
+            series=series_in, mapping=mapping, make_unmapped_values_nan=True
+        )
+        assert out.equals(
+            pd.Series(["Country 1", np.nan, np.nan, np.nan]).astype("category")
+        )
+        assert out.dtype == "category"
+
 
 class TestRenameCategories:
     def test_rename_categories(self):
@@ -942,9 +967,22 @@ class TestRenameCategories:
             "country_01": "Country 1",
             "country_02": "Country 1",
         }
-        out = dataframes.rename_categories(
-            series=series_in, mapping=mapping
+        out = dataframes.rename_categories(series=series_in, mapping=mapping)
+        assert out.equals(series_out)
+        assert out.dtype == "category"
+
+    def test_rename_categories_with_nans(self):
+        series_in = pd.Series(
+            ["country_01", "country_02", "country_03", np.nan]
+        ).astype("category")
+        series_out = pd.Series(["Country 1", np.nan, "country_03", np.nan]).astype(
+            "category"
         )
+        mapping = {
+            "country_01": "Country 1",
+            "country_02": np.nan,
+        }
+        out = dataframes.rename_categories(series=series_in, mapping=mapping)
         assert out.equals(series_out)
         assert out.dtype == "category"
 

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -930,6 +930,25 @@ class TestMapSeries:
         assert out.dtype == "category"
 
 
+class TestRenameCategories:
+    def test_rename_categories(self):
+        series_in = pd.Series(
+            ["country_01", "country_02", "country_03", np.nan]
+        ).astype("category")
+        series_out = pd.Series(["Country 1", "Country 1", "country_03", np.nan]).astype(
+            "category"
+        )
+        mapping = {
+            "country_01": "Country 1",
+            "country_02": "Country 1",
+        }
+        out = dataframes.rename_categories(
+            series=series_in, mapping=mapping
+        )
+        assert out.equals(series_out)
+        assert out.dtype == "category"
+
+
 class TestConcatenate:
     def test_concat_categoricals(self):
         a = pd.DataFrame({"x": ["a"], "d": [1]}).astype("category")


### PR DESCRIPTION
Turned out `series.replace(category_mapping)` is memory inefficient. I had to come up with a version that supports non-unique category map (two categories mapping to the same one). This should fix failing step `data/garden/who/2022-09-30/ghe` in ETL.