### PR TITLE
feature: unarchive files (zip)

### DIFF
--- a/owid/datautils/io/local.py
+++ b/owid/datautils/io/local.py
@@ -87,8 +87,8 @@ def decompress_file(
     input_file: Union[str, Path],
     output_folder: Union[str, Path],
     overwrite: bool = False,
-    **kwargs
-):
+    **kwargs: Any
+) -> None:
     """Extract a local zip file, or a remote zip file given its URL.
 
     Parameters
@@ -101,11 +101,10 @@ def decompress_file(
         Overwrite decompressed content if it already exists (otherwise raise an error).
 
     """
-
     if str(input_file).startswith("http"):
         # If input path is a URL, first download the zipped file into a temporary folder.
         with tempfile.NamedTemporaryFile() as temp_file:
-            download_file_from_url(input_file, temp_file.name, **kwargs)
+            download_file_from_url(str(input_file), temp_file.name, **kwargs)
             # Open the zipped file.
             zip_file = zipfile.ZipFile(temp_file.name)
     else:

--- a/owid/datautils/io/local.py
+++ b/owid/datautils/io/local.py
@@ -1,10 +1,13 @@
 """Input/Output functions for local files."""
 
 import json
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import Any, Hashable, List, Tuple, Union
 
 from owid.datautils.common import warn_on_list_of_entities
+from owid.datautils.web import download_file_from_url
 
 
 def _load_json_data_and_duplicated_keys(
@@ -78,3 +81,46 @@ def save_json(data: Any, json_file: Union[str, Path], **kwargs: Any) -> None:
 
     with open(json_file, "w") as _json_file:
         json.dump(data, _json_file, **kwargs)
+
+
+def decompress_file(
+    input_file: Union[str, Path],
+    output_folder: Union[str, Path],
+    overwrite: bool = False,
+    **kwargs
+):
+    """Extract a local zip file, or a remote zip file given its URL.
+
+    Parameters
+    ----------
+    input_file : Union[str, Path]
+        Path to local zip file, or URL of a remote zip file.
+    output_folder : Union[str, Path]
+        Path to local folder
+    overwrite : bool
+        Overwrite decompressed content if it already exists (otherwise raise an error).
+
+    """
+
+    if str(input_file).startswith("http"):
+        # If input path is a URL, first download the zipped file into a temporary folder.
+        with tempfile.NamedTemporaryFile() as temp_file:
+            download_file_from_url(input_file, temp_file.name, **kwargs)
+            # Open the zipped file.
+            zip_file = zipfile.ZipFile(temp_file.name)
+    else:
+        # Directly open the local zipped file.
+        zip_file = zipfile.ZipFile(input_file)
+
+    # If the content to be written in output folder already exists, raise an error,
+    # unless 'overwrite' is set to True, in which case the existing file will be overwritten.
+    # Path to new file to be created.
+    new_file = Path(output_folder) / Path(zip_file.namelist()[0])
+    if new_file.exists() and not overwrite:
+        raise FileExistsError(
+            "Output already exists. Either change output_folder or use overwrite=True."
+        )
+
+    # Unzip the file and save it in the local output folder.
+    # Note that, if output_folder path does not exist, the following command will create it.
+    zip_file.extractall(output_folder)

--- a/tests/io/test_local.py
+++ b/tests/io/test_local.py
@@ -5,6 +5,7 @@
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Union
 
 from pytest import warns, raises
 from unittest.mock import patch, mock_open
@@ -61,7 +62,9 @@ def test_save_json(tmpdir):
     save_json(data, tmpdir / "test.json")
 
 
-def _create_compressed_file_with_content(file_name, containing_dir, content):
+def _create_compressed_file_with_content(
+    file_name: str, containing_dir: Union[str, Path], content: str
+) -> None:
     # Create a file with some example content.
     file_inside = Path(containing_dir) / file_name
     with open(file_inside, "w") as _file_inside:
@@ -72,8 +75,8 @@ def _create_compressed_file_with_content(file_name, containing_dir, content):
 
 
 def _create_compressed_file_with_content_within_folder(
-    file_name, containing_dir, sub_dir_name, content
-):
+    file_name: str, containing_dir: Union[str, Path], sub_dir_name: str, content: str
+) -> None:
     # Create a folder that will later be compressed.
     to_compress_dir = Path(containing_dir) / sub_dir_name
     to_compress_dir.mkdir()

--- a/tests/io/test_local.py
+++ b/tests/io/test_local.py
@@ -2,10 +2,14 @@
 
 """
 
-from pytest import warns
+import tempfile
+import zipfile
+from pathlib import Path
+
+from pytest import warns, raises
 from unittest.mock import patch, mock_open
 
-from owid.datautils.io.local import load_json, save_json
+from owid.datautils.io.local import decompress_file, load_json, save_json
 
 
 class TestLoadJson:
@@ -55,3 +59,123 @@ class TestLoadJson:
 def test_save_json(tmpdir):
     data = {"1": "10", "2": "20"}
     save_json(data, tmpdir / "test.json")
+
+
+def _create_compressed_file_with_content(file_name, containing_dir, content):
+    # Create a file with some example content.
+    file_inside = Path(containing_dir) / file_name
+    with open(file_inside, "w") as _file_inside:
+        _file_inside.write(content)
+    # Compress that folder.
+    with zipfile.ZipFile(file_inside.with_suffix(".zip"), "w") as zip_file:
+        zip_file.write(file_inside, file_inside.name)
+
+
+def _create_compressed_file_with_content_within_folder(
+    file_name, containing_dir, sub_dir_name, content
+):
+    # Create a folder that will later be compressed.
+    to_compress_dir = Path(containing_dir) / sub_dir_name
+    to_compress_dir.mkdir()
+    # Create a file inside that folder with some example content.
+    file_inside = to_compress_dir / file_name
+    with open(file_inside, "w") as _file_inside:
+        _file_inside.write(content)
+    # Compress that folder.
+    with zipfile.ZipFile(to_compress_dir.with_suffix(".zip"), "w") as zip_file:
+        zip_file.write(file_inside, file_inside.relative_to(to_compress_dir.parent))
+
+
+class TestDecompressFile:
+    def test_decompress_file_with_content(self, tmp_path):
+        # Create a compressed file with some example content.
+        example_content = "Example content."
+        file_name = "example_file.txt"
+        _create_compressed_file_with_content(
+            file_name=file_name, containing_dir=tmp_path, content=example_content
+        )
+        # Decompress the original file in a new folder.
+        new_dir = Path(tmp_path) / "new_dir"
+        decompress_file(
+            input_file=(Path(tmp_path) / file_name).with_suffix(".zip"),
+            output_folder=new_dir,
+        )
+        # Check that, inside the new folder, we find the original (decompressed) folder and the file inside.
+        recovered_file = new_dir / file_name
+        assert new_dir.is_dir()
+        assert recovered_file.is_file()
+        # Read the file to check that its content is the expected one.
+        with open(recovered_file, "r") as _recovered_file:
+            assert _recovered_file.read() == example_content
+
+    def test_decompress_file_with_content_within_folder(self, tmp_path):
+        # Create a compressed file with some example content within a folder.
+        example_content = "Example content."
+        file_name = "example_file.txt"
+        sub_dir_name = "example_dir"
+        _create_compressed_file_with_content_within_folder(
+            file_name=file_name,
+            containing_dir=tmp_path,
+            sub_dir_name=sub_dir_name,
+            content=example_content,
+        )
+        # Decompress the original folder in a new folder.
+        new_dir = Path(tmp_path) / "new_dir"
+        decompress_file(
+            input_file=(Path(tmp_path) / sub_dir_name).with_suffix(".zip"),
+            output_folder=new_dir,
+        )
+        # Check that, inside the new folder, we find the original (decompressed) folder and the file inside.
+        recovered_file = new_dir / sub_dir_name / file_name
+        assert new_dir.is_dir()
+        assert recovered_file.is_file()
+        # Read the file to check that its content is the expected one.
+        with open(recovered_file, "r") as _recovered_file:
+            assert _recovered_file.read() == example_content
+
+    def test_overwrite_file(self, tmp_path):
+        # Create a compressed file with some example content.
+        example_content = "Example content."
+        file_name = "example_file.txt"
+        _create_compressed_file_with_content(
+            file_name=file_name, containing_dir=tmp_path, content=example_content
+        )
+        # Decompress the original file in a new folder.
+        new_dir = Path(tmp_path) / "new_dir"
+        decompress_file(
+            input_file=(Path(tmp_path) / file_name).with_suffix(".zip"),
+            output_folder=new_dir,
+        )
+        # Decompress file again and overwrite previous.
+        decompress_file(
+            input_file=(Path(tmp_path) / file_name).with_suffix(".zip"),
+            output_folder=new_dir,
+            overwrite=True,
+        )
+        # Check that, inside the new folder, we find the original (decompressed) folder and the file inside.
+        recovered_file = new_dir / file_name
+        assert new_dir.is_dir()
+        assert recovered_file.is_file()
+        # Read the file to check that its content is the expected one.
+        with open(recovered_file, "r") as _recovered_file:
+            assert _recovered_file.read() == example_content
+
+    def test_raise_error_if_file_exists(self, tmp_path):
+        # Create a compressed file with some example content.
+        example_content = "Example content."
+        file_name = "example_file.txt"
+        _create_compressed_file_with_content(
+            file_name=file_name, containing_dir=tmp_path, content=example_content
+        )
+        # Decompress the original file in a new folder.
+        new_dir = Path(tmp_path) / "new_dir"
+        decompress_file(
+            input_file=(Path(tmp_path) / file_name).with_suffix(".zip"),
+            output_folder=new_dir,
+        )
+        # Try to decompress file again, which should fail because file exists (and overwrite is by default False).
+        with raises(FileExistsError):
+            decompress_file(
+                input_file=(Path(tmp_path) / file_name).with_suffix(".zip"),
+                output_folder=new_dir,
+            )


### PR DESCRIPTION
Migrate `extract_zip` to `io.local.decompress_file`. I renamed it that way because we may want to generalize it to other compressed formats in the future.
I added tests checking the functionality for local files, not remote files.
