### PR TITLE
feature(df): read from arbitrary files (csv, xlsx, json, etc.)

### DIFF
--- a/owid/datautils/io/df.py
+++ b/owid/datautils/io/df.py
@@ -1,50 +1,84 @@
 """DataFrame io operations."""
 import pandas as pd
+from pathlib import Path
 from owid.datautils.decorators import enable_file_download
-from typing import Any
+from typing import Any, Optional, Union, List
 
 
-@enable_file_download("filepath")
-def read_csv(filepath: str, **kwargs: Any) -> pd.DataFrame:
-    """Read a CSV.
+COMPRESSION_SUPPORTED = ["gz", "bz2", "zip", "xz", "zst", "tar"]
 
-    It uses standard pandas function pandas.read_csv but adds the ability to read from a URL in some cases where
-    pandas.read_csv does not work.
+
+@enable_file_download("file_path")
+def from_file(
+    file_path: Union[str, Path], file_type: Optional[str] = None, **kwargs: Any
+) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+    """Read a CSV or excel file.
+
+    It uses standard pandas function pandas.read_* but adds the ability to read from a URL in some
+    cases where pandas does not work.
+
+    The function will infer the extension of `file_path` by simply taking what follows the last ".". For example:
+    "file.csv" will have an extension ".csv"; "http://my/domain/file.xlsx" will have an extension "xlsx".
+
+    Reading from compressed files will not work by default, unless you provide a `file_type`.
 
     Parameters
     ----------
     filepath : str
         Path or url to file.
+    file_type : str
+        File type. For instance, if reading from a zip-compressed file that originally was a CSV,
+         `file_type` should be "csv". Reading from compressed files is supported for "csv", "dta" and "json".
     kwargs :
-        pandas.read_csv arguments.
+        pandas.read_* arguments.
 
     Returns
     -------
     pandas.DataFrame:
         Read dataframe.
     """
-    df: pd.DataFrame = pd.read_csv(filepath, **kwargs)
-    return df
+    # Ensure file_path is a Path object.
+    file_path = Path(file_path)
 
+    # Ensure extension is lower case and does not start with '.'.
+    extension = file_path.suffix.lstrip(".").lower()
 
-@enable_file_download("filepath")
-def read_excel(filepath: str, **kwargs: Any) -> pd.DataFrame:
-    """Read an excel file (xlsx or xls).
+    # If compressed file, raise an exception unless file_type is given
+    if extension in COMPRESSION_SUPPORTED:
+        if file_type:
+            extension = file_type
+        else:
+            raise ValueError(
+                "To be able to read from a compressed file, you need to provide a value"
+                " for `file_type`."
+            )
 
-    It uses standard pandas function pandas.read_excel but adds the ability to read from a URL in some cases where
-    pandas.read_excel does not work.
+    # Check path is valid
+    if not file_path.exists():
+        raise FileNotFoundError(f"Cannot find file: {file_path}")
 
-    Parameters
-    ----------
-    filepath : str
-        Path or url to file.
-    kwargs :
-        pandas.read_excel arguments.
+    # Available output methods (some of them may need additional dependencies to work).
+    output_methods = {
+        "csv": pd.read_csv,
+        "dta": pd.read_stata,
+        "feather": pd.read_feather,
+        "hdf": pd.read_hdf,
+        "html": pd.read_html,
+        "json": pd.read_json,
+        "parquet": pd.read_parquet,
+        "pickle": pd.read_pickle,
+        "pkl": pd.read_pickle,
+        "xlsx": pd.read_excel,
+        "xml": pd.read_xml,
+    }
+    if extension not in output_methods:
+        raise ValueError(
+            "Failed reading dataframe because of an unknown file extension:"
+            f" {extension}"
+        )
+    # Select the appropriate storing method.
+    read_function = output_methods[extension]
 
-    Returns
-    -------
-    pandas.DataFrame:
-        Read dataframe.
-    """
-    df: pd.DataFrame = pd.read_excel(filepath, **kwargs)
+    # Load file using the chosen read function and the appropriate arguments.
+    df: pd.DataFrame = read_function(file_path, **kwargs)
     return df

--- a/owid/datautils/io/df.py
+++ b/owid/datautils/io/df.py
@@ -4,8 +4,8 @@ from owid.datautils.decorators import enable_file_download
 from typing import Any
 
 
-@enable_file_download("path_or_url")
-def read_csv(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
+@enable_file_download("filepath")
+def read_csv(filepath: str, **kwargs: Any) -> pd.DataFrame:
     """Read a CSV.
 
     It uses standard pandas function pandas.read_csv but adds the ability to read from a URL in some cases where
@@ -13,9 +13,9 @@ def read_csv(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
 
     Parameters
     ----------
-    path_or_url : str
+    filepath : str
         Path or url to file.
-    kwargs : _type_
+    kwargs :
         pandas.read_csv arguments.
 
     Returns
@@ -23,12 +23,12 @@ def read_csv(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
     pandas.DataFrame:
         Read dataframe.
     """
-    df: pd.DataFrame = pd.read_csv(path_or_url, **kwargs)
+    df: pd.DataFrame = pd.read_csv(filepath, **kwargs)
     return df
 
 
-@enable_file_download("path_or_url")
-def read_excel(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
+@enable_file_download("filepath")
+def read_excel(filepath: str, **kwargs: Any) -> pd.DataFrame:
     """Read an excel file (xlsx or xls).
 
     It uses standard pandas function pandas.read_excel but adds the ability to read from a URL in some cases where
@@ -36,15 +36,15 @@ def read_excel(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
 
     Parameters
     ----------
-    path_or_url : str
+    filepath : str
         Path or url to file.
-    kwargs : _type_
-        pandas.read_csv arguments.
+    kwargs :
+        pandas.read_excel arguments.
 
     Returns
     -------
     pandas.DataFrame:
         Read dataframe.
     """
-    df: pd.DataFrame = pd.read_excel(path_or_url, **kwargs)
+    df: pd.DataFrame = pd.read_excel(filepath, **kwargs)
     return df

--- a/owid/datautils/io/df.py
+++ b/owid/datautils/io/df.py
@@ -12,7 +12,7 @@ COMPRESSION_SUPPORTED = ["gz", "bz2", "zip", "xz", "zst", "tar"]
 def from_file(
     file_path: Union[str, Path], file_type: Optional[str] = None, **kwargs: Any
 ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
-    """Loads a file as a pandas DataFrame.
+    """Load a file as a pandas DataFrame.
 
     It uses standard pandas function pandas.read_* but adds the ability to read from a URL in some
     cases where pandas does not work.
@@ -73,7 +73,7 @@ def from_file(
         "xlsx": pd.read_excel,
         "xml": pd.read_xml,
     }
-    if extension not in output_methods:
+    if extension not in input_methods:
         raise ValueError(
             "Failed reading dataframe because of an unknown file extension:"
             f" {extension}"

--- a/owid/datautils/io/df.py
+++ b/owid/datautils/io/df.py
@@ -12,13 +12,13 @@ COMPRESSION_SUPPORTED = ["gz", "bz2", "zip", "xz", "zst", "tar"]
 def from_file(
     file_path: Union[str, Path], file_type: Optional[str] = None, **kwargs: Any
 ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
-    """Read a CSV or excel file.
+    """Loads a file as a pandas DataFrame.
 
     It uses standard pandas function pandas.read_* but adds the ability to read from a URL in some
     cases where pandas does not work.
 
     The function will infer the extension of `file_path` by simply taking what follows the last ".". For example:
-    "file.csv" will have an extension ".csv"; "http://my/domain/file.xlsx" will have an extension "xlsx".
+    "file.csv" will be read as a csv file, and "http://my/domain/file.xlsx" will be read as an excel file.
 
     Reading from compressed files will not work by default, unless you provide a `file_type`.
 
@@ -27,8 +27,10 @@ def from_file(
     filepath : str
         Path or url to file.
     file_type : str
-        File type. For instance, if reading from a zip-compressed file that originally was a CSV,
-         `file_type` should be "csv". Reading from compressed files is supported for "csv", "dta" and "json".
+        File type of the data file. By default is None, as it is only required when reading compressed files.
+        This is typically equivalent to the file extension. However, when reading a
+        compressed file, this refers to the actual file that is compressed (not the compressed file extension).
+        Reading from compressed files is supported for "csv", "dta" and "json".
     kwargs :
         pandas.read_* arguments.
 
@@ -57,8 +59,8 @@ def from_file(
     if not file_path.exists():
         raise FileNotFoundError(f"Cannot find file: {file_path}")
 
-    # Available output methods (some of them may need additional dependencies to work).
-    output_methods = {
+    # Available input methods (some of them may need additional dependencies to work).
+    input_methods = {
         "csv": pd.read_csv,
         "dta": pd.read_stata,
         "feather": pd.read_feather,
@@ -76,8 +78,8 @@ def from_file(
             "Failed reading dataframe because of an unknown file extension:"
             f" {extension}"
         )
-    # Select the appropriate storing method.
-    read_function = output_methods[extension]
+    # Select the appropriate reading method.
+    read_function = input_methods[extension]
 
     # Load file using the chosen read function and the appropriate arguments.
     df: pd.DataFrame = read_function(file_path, **kwargs)

--- a/owid/datautils/io/df.py
+++ b/owid/datautils/io/df.py
@@ -1,0 +1,50 @@
+"""DataFrame io operations."""
+import pandas as pd
+from owid.datautils.decorators import enable_file_download
+from typing import Any
+
+
+@enable_file_download("path_or_url")
+def read_csv(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
+    """Read a CSV.
+
+    It uses standard pandas function pandas.read_csv but adds the ability to read from a URL in some cases where
+    pandas.read_csv does not work.
+
+    Parameters
+    ----------
+    path_or_url : str
+        Path or url to file.
+    kwargs : _type_
+        pandas.read_csv arguments.
+
+    Returns
+    -------
+    pandas.DataFrame:
+        Read dataframe.
+    """
+    df: pd.DataFrame = pd.read_csv(path_or_url, **kwargs)
+    return df
+
+
+@enable_file_download("path_or_url")
+def read_excel(path_or_url: str, **kwargs: Any) -> pd.DataFrame:
+    """Read an excel file (xlsx or xls).
+
+    It uses standard pandas function pandas.read_excel but adds the ability to read from a URL in some cases where
+    pandas.read_excel does not work.
+
+    Parameters
+    ----------
+    path_or_url : str
+        Path or url to file.
+    kwargs : _type_
+        pandas.read_csv arguments.
+
+    Returns
+    -------
+    pandas.DataFrame:
+        Read dataframe.
+    """
+    df: pd.DataFrame = pd.read_excel(path_or_url, **kwargs)
+    return df

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [[package]]
 name = "anyio"
-version = "3.6.1"
+version = "3.6.2"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "dev"
 optional = false
@@ -21,7 +21,7 @@ sniffio = ">=1.1"
 [package.extras]
 doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
 test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
-trio = ["trio (>=0.16)"]
+trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
 name = "appnope"
@@ -191,14 +191,14 @@ dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (=
 
 [[package]]
 name = "boto3"
-version = "1.24.91"
+version = "1.24.94"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.91,<1.28.0"
+botocore = ">=1.27.94,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -207,8 +207,8 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.24.91"
-description = "Type annotations for boto3 1.24.91 generated with mypy-boto3-builder 7.11.10"
+version = "1.24.94"
+description = "Type annotations for boto3 1.24.94 generated with mypy-boto3-builder 7.11.10"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
@@ -543,7 +543,7 @@ xray = ["mypy-boto3-xray (>=1.24.0,<1.25.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.91"
+version = "1.27.94"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -559,7 +559,7 @@ crt = ["awscrt (==0.14.0)"]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.27.91"
+version = "1.27.94"
 description = "Type annotations and code completion for botocore"
 category = "dev"
 optional = false
@@ -707,7 +707,7 @@ python-versions = ">=3.6"
 name = "et-xmlfile"
 version = "1.1.0"
 description = "An implementation of lxml.xmlfile for the standard library"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -940,7 +940,7 @@ toml = {version = ">=0.10.2", markers = "python_version > \"3.6\""}
 
 [[package]]
 name = "ipykernel"
-version = "6.16.0"
+version = "6.16.1"
 description = "IPython Kernel for Jupyter"
 category = "dev"
 optional = false
@@ -960,7 +960,8 @@ tornado = ">=6.1"
 traitlets = ">=5.1.0"
 
 [package.extras]
-test = ["flaky", "ipyparallel", "pre-commit", "pytest-cov", "pytest-timeout", "pytest (>=6.0)"]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx", "sphinxcontrib-github-alt"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest-cov", "pytest-timeout", "pytest (>=7.0)"]
 
 [[package]]
 name = "ipython"
@@ -1095,7 +1096,7 @@ qtconsole = "*"
 
 [[package]]
 name = "jupyter-client"
-version = "7.4.2"
+version = "7.4.3"
 description = "Jupyter protocol implementation and client libraries"
 category = "dev"
 optional = false
@@ -1112,7 +1113,7 @@ traitlets = "*"
 
 [package.extras]
 doc = ["ipykernel", "myst-parser", "sphinx-rtd-theme", "sphinx (>=1.3.6)", "sphinxcontrib-github-alt"]
-test = ["codecov", "coverage", "ipykernel (>=6.5)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
+test = ["codecov", "coverage", "ipykernel (>=6.12)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-console"
@@ -1134,7 +1135,7 @@ test = ["pexpect"]
 
 [[package]]
 name = "jupyter-core"
-version = "4.11.1"
+version = "4.11.2"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "dev"
 optional = false
@@ -1145,7 +1146,7 @@ pywin32 = {version = ">=1.0", markers = "sys_platform == \"win32\" and platform_
 traitlets = "*"
 
 [package.extras]
-test = ["pytest-timeout", "pytest-cov", "pytest", "pre-commit", "ipykernel"]
+test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-server"
@@ -1191,6 +1192,20 @@ description = "Jupyter interactive widgets for JupyterLab"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "lxml"
+version = "4.9.1"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["beautifulsoup4"]
+source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "markupsafe"
@@ -1275,8 +1290,8 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-boto3-s3"
-version = "1.24.76"
-description = "Type annotations for boto3.S3 1.24.76 service generated with mypy-boto3-builder 7.11.9"
+version = "1.24.94"
+description = "Type annotations for boto3.S3 1.24.94 service generated with mypy-boto3-builder 7.11.10"
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -1344,7 +1359,7 @@ sphinx = ["sphinx-book-theme", "Sphinx (>=1.7)", "myst-parser", "moto", "mock", 
 
 [[package]]
 name = "nbconvert"
-version = "7.2.1"
+version = "7.2.2"
 description = "Converting Jupyter Notebooks"
 category = "dev"
 optional = false
@@ -1435,17 +1450,29 @@ test = ["pytest", "coverage", "requests", "testpath", "nbval", "selenium (==4.1.
 
 [[package]]
 name = "notebook-shim"
-version = "0.1.0"
+version = "0.2.0"
 description = "A shim layer for notebook traits and config"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-jupyter-server = ">=1.8,<2.0"
+jupyter-server = ">=1.8,<3"
 
 [package.extras]
-test = ["pytest-console-scripts", "pytest-tornasync", "pytest"]
+test = ["pytest-tornasync", "pytest-console-scripts", "pytest"]
+
+[[package]]
+name = "numexpr"
+version = "2.8.3"
+description = "Fast numerical expression evaluator for NumPy"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = ">=1.13.3"
+packaging = "*"
 
 [[package]]
 name = "numpy"
@@ -1459,7 +1486,7 @@ python-versions = ">=3.8"
 name = "openpyxl"
 version = "3.0.10"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -1501,7 +1528,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.5.0"
+version = "1.5.1"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -1556,7 +1583,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "pbr"
-version = "5.10.0"
+version = "5.11.0"
 description = "Python Build Reasonableness"
 category = "dev"
 optional = false
@@ -1629,7 +1656,7 @@ wcwidth = "*"
 
 [[package]]
 name = "psutil"
-version = "5.9.2"
+version = "5.9.3"
 description = "Cross-platform lib for process and system monitoring in Python."
 category = "dev"
 optional = false
@@ -1794,7 +1821,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.4"
+version = "2022.5"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -2103,7 +2130,7 @@ tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
 
 [[package]]
 name = "stevedore"
-version = "4.0.1"
+version = "4.1.0"
 description = "Manage dynamic plugins for Python applications"
 category = "dev"
 optional = false
@@ -2126,6 +2153,22 @@ docs = ["furo", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twis
 tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio", "pytest (>=6.0)", "simplejson"]
 
 [[package]]
+name = "tables"
+version = "3.7.0"
+description = "Hierarchical datasets for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+numexpr = ">=2.6.2"
+numpy = ">=1.19.0"
+packaging = "*"
+
+[package.extras]
+doc = ["sphinx (>=1.1)", "sphinx-rtd-theme", "numpydoc", "ipython"]
+
+[[package]]
 name = "terminado"
 version = "0.16.0"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
@@ -2143,17 +2186,17 @@ test = ["pre-commit", "pytest-timeout", "pytest (>=6.0)"]
 
 [[package]]
 name = "tinycss2"
-version = "1.1.1"
+version = "1.2.1"
 description = "A tiny CSS parser"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 webencodings = ">=0.4"
 
 [package.extras]
-test = ["coverage", "pytest-isort", "pytest-flake8", "pytest-cov", "pytest"]
+test = ["flake8", "isort", "pytest"]
 doc = ["sphinx-rtd-theme", "sphinx"]
 
 [[package]]
@@ -2182,13 +2225,14 @@ python-versions = ">= 3.7"
 
 [[package]]
 name = "traitlets"
-version = "5.4.0"
+version = "5.5.0"
 description = ""
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["pre-commit", "pytest"]
 
 [[package]]
@@ -2311,7 +2355,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7790d5095bc1dc304eb01af0d76b03568a91179e1d068c826c7f254f739f0042"
+content-hash = "53266cbfd768fb4a71f4c51df7494c76c19c33b198cc07513ea0699698fde095"
 
 [metadata.files]
 alabaster = [
@@ -2502,6 +2546,7 @@ jupyter-core = []
 jupyter-server = []
 jupyterlab-pygments = []
 jupyterlab-widgets = []
+lxml = []
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
@@ -2568,6 +2613,7 @@ nbformat = []
 nest-asyncio = []
 notebook = []
 notebook-shim = []
+numexpr = []
 numpy = []
 openpyxl = []
 owid-catalog = []
@@ -2825,6 +2871,7 @@ structlog = [
     {file = "structlog-21.5.0-py3-none-any.whl", hash = "sha256:fd7922e195262b337da85c2a91c84be94ccab1f8fd1957bd6986f6904e3761c8"},
     {file = "structlog-21.5.0.tar.gz", hash = "sha256:68c4c29c003714fe86834f347cb107452847ba52414390a7ee583472bde00fc9"},
 ]
+tables = []
 terminado = []
 tinycss2 = []
 toml = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -704,6 +704,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "et-xmlfile"
+version = "1.1.0"
+description = "An implementation of lxml.xmlfile for the standard library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "executing"
 version = "1.1.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -1446,6 +1454,17 @@ description = "NumPy is the fundamental package for array computing with Python.
 category = "main"
 optional = false
 python-versions = ">=3.8"
+
+[[package]]
+name = "openpyxl"
+version = "3.0.10"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+et-xmlfile = "*"
 
 [[package]]
 name = "owid-catalog"
@@ -2292,7 +2311,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "36a37113069744a7aefbf267daffef290c77ec2793974904d1f97b6cf657e0cd"
+content-hash = "7790d5095bc1dc304eb01af0d76b03568a91179e1d068c826c7f254f739f0042"
 
 [metadata.files]
 alabaster = [
@@ -2396,6 +2415,10 @@ docutils = [
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
+]
+et-xmlfile = [
+    {file = "et_xmlfile-1.1.0-py3-none-any.whl", hash = "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"},
+    {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
 ]
 executing = []
 fastjsonschema = []
@@ -2546,6 +2569,7 @@ nest-asyncio = []
 notebook = []
 notebook-shim = []
 numpy = []
+openpyxl = []
 owid-catalog = []
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ structlog = "^21.5.0"
 colorama = "^0.4.4"
 mypy-boto3-s3 = "^1.21.23"
 owid-catalog = "^0.3.2"
-openpyxl = "^3.0.10"
 
 
 [tool.poetry.dev-dependencies]
@@ -43,6 +42,9 @@ ipdb = "^0.13.9"
 ipykernel = "^6.13.0"
 flake8-rst-docstrings =  "^0.2.6"
 jupyter = "^1.0.0"
+openpyxl = "^3.0.10"
+lxml = "^4.9.1"
+tables = "^3.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ structlog = "^21.5.0"
 colorama = "^0.4.4"
 mypy-boto3-s3 = "^1.21.23"
 owid-catalog = "^0.3.2"
+openpyxl = "^3.0.10"
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/io/test_df.py
+++ b/tests/io/test_df.py
@@ -1,0 +1,20 @@
+"""Test functions in owid.datautils.io.local module.
+
+"""
+from owid.datautils.io.df import read_csv
+from typing import Any
+import pandas as pd
+
+
+class TestLoadDf:
+    def test_read_csv(self, tmpdir):
+        file = tmpdir / "test.csv"
+        _create_csv_file(file)
+        df = read_csv(str(file))
+        df_ = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+        assert df.equals(df_)
+
+
+def _create_csv_file(file: Any) -> Any:
+    content = "a,b,c\n1,2,3"
+    file.write_text(content, encoding="utf-8")

--- a/tests/io/test_df.py
+++ b/tests/io/test_df.py
@@ -1,20 +1,32 @@
 """Test functions in owid.datautils.io.local module.
 
 """
-from owid.datautils.io.df import read_csv
+from owid.datautils.io.df import read_csv, read_excel
 from typing import Any
 import pandas as pd
 
 
 class TestLoadDf:
+    df_original = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+
     def test_read_csv(self, tmpdir):
         file = tmpdir / "test.csv"
         _create_csv_file(file)
         df = read_csv(str(file))
-        df_ = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
-        assert df.equals(df_)
+        assert df.equals(self.df_original)
+
+    def test_read_excel(self, tmpdir):
+        file = tmpdir / "test.xlsx"
+        _create_excel_file(file)
+        df = read_excel(str(file))
+        assert df.equals(self.df_original)
 
 
 def _create_csv_file(file: Any) -> Any:
     content = "a,b,c\n1,2,3"
     file.write_text(content, encoding="utf-8")
+
+
+def _create_excel_file(file: Any) -> Any:
+    df = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+    df.to_excel(file, index=False)

--- a/tests/io/test_df.py
+++ b/tests/io/test_df.py
@@ -1,32 +1,95 @@
 """Test functions in owid.datautils.io.local module.
 
 """
-from owid.datautils.io.df import read_csv, read_excel
+from owid.datautils.io.df import from_file
 from typing import Any
 import pandas as pd
+from pytest import raises
 
 
 class TestLoadDf:
-    df_original = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+    df_original = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
 
-    def test_read_csv(self, tmpdir):
-        file = tmpdir / "test.csv"
-        _create_csv_file(file)
-        df = read_csv(str(file))
+    def test_from_file_basic(self, tmpdir):
+        output_methods = {
+            "csv": self.df_original.to_csv,
+            # "dta": self.df_original.to_stata,
+            "feather": self.df_original.to_feather,
+            "parquet": self.df_original.to_parquet,
+            "pickle": self.df_original.to_pickle,
+            "pkl": self.df_original.to_pickle,
+            "xlsx": self.df_original.to_excel,
+            "xml": self.df_original.to_xml,
+        }
+        for extension, funct in output_methods.items():
+            file = tmpdir / f"test.{extension}"
+            if extension in ["dta", "pickle", "pkl", "feather"]:
+                funct(file)
+            else:
+                funct(file, index=False)
+            df = from_file(str(file))
+            assert df.equals(self.df_original)
+
+    def test_from_file_json(self, tmpdir):
+        file = tmpdir / "test.json"
+        self.df_original.to_json(file, orient="records")
+        df = from_file(str(file))
+        assert df.equals(self.df_original)
+        # Compressed
+        file = tmpdir / "test.zip"
+        self.df_original.to_json(file, orient="records")
+        df = from_file(str(file), file_type="json")
         assert df.equals(self.df_original)
 
-    def test_read_excel(self, tmpdir):
-        file = tmpdir / "test.xlsx"
-        _create_excel_file(file)
-        df = read_excel(str(file))
+    def test_from_file_html(self, tmpdir):
+        file = tmpdir / "test.html"
+        self.df_original.to_html(file, index=False)
+        df = from_file(str(file))[0]
         assert df.equals(self.df_original)
+
+    def test_from_file_hdf(self, tmpdir):  # hdf5?
+        file = tmpdir / "test.hdf"
+        self.df_original.to_hdf(file, key="df")
+        df = from_file(str(file))
+        assert df.equals(self.df_original)
+
+    def test_from_file_dta(self, tmpdir):
+        file = tmpdir / "test.dta"
+        self.df_original.to_stata(file, write_index=False)
+        df = from_file(str(file))
+        assert df.astype(int).equals(self.df_original.astype(int))
+        # Compressed
+        file = tmpdir / "test.zip"
+        self.df_original.to_stata(file, write_index=False)
+        df = from_file(str(file), file_type="dta")
+        assert df.astype(int).equals(self.df_original.astype(int))
+
+    def test_from_file_csv_zip(self, tmpdir):
+        file = tmpdir / "test.zip"
+        self.df_original.to_csv(file, index=False)
+        df = from_file(str(file), file_type="csv")
+        assert df.equals(self.df_original)
+
+    def test_from_file_filenotfound(self, tmpdir):
+        """File does not exist."""
+        with raises(FileNotFoundError):
+            file = tmpdir / "test.csv"
+            _ = from_file(str(file))
+
+    def test_from_file_zip_err(self, tmpdir):
+        """Compressed file, but no file type is given."""
+        with raises(ValueError):
+            file = tmpdir / "test.zip"
+            _ = from_file(str(file))
+
+    def test_from_file_format_err(self, tmpdir):
+        """Unknown file format."""
+        with raises(ValueError):
+            file = tmpdir / "test.error"
+            _create_csv_file(file)
+            _ = from_file(str(file))
 
 
 def _create_csv_file(file: Any) -> Any:
-    content = "a,b,c\n1,2,3"
+    content = "a,b,c\n1,2,3\n4,5,6"
     file.write_text(content, encoding="utf-8")
-
-
-def _create_excel_file(file: Any) -> Any:
-    df = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
-    df.to_excel(file, index=False)


### PR DESCRIPTION
Add `owid.datautils.io.df` module to enable reading from CSV and Excel files.


Pandas' extra libraries to read from xlsx and markdown have been left out of dependencies (as pandas does). Users should install them manually. These are:

```
openpyxl = "^3.0.10"
lxml = "^4.9.1"
tables = "^3.7.0"
```

Optionally, we can set up some extra dependencies to install these, so that e.g. `pip install  owid-datautils-py[full]` would install all of them too.